### PR TITLE
Fix XCODE MTC Error

### DIFF
--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -225,7 +225,7 @@
             } else {
                 NSLog(@"PushPlugin.register: setting badge to true");
                 clearBadge = YES;
-                dispatch_sync(dispatch_get_main_queue(), ^{
+                dispatch_async(dispatch_get_main_queue(), ^{
                      [[UIApplication sharedApplication] setApplicationIconBadgeNumber:0];
                 });
             }

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -225,7 +225,9 @@
             } else {
                 NSLog(@"PushPlugin.register: setting badge to true");
                 clearBadge = YES;
-                [[UIApplication sharedApplication] setApplicationIconBadgeNumber:0];
+                dispatch_sync(dispatch_get_main_queue(), ^{
+                     [[UIApplication sharedApplication] setApplicationIconBadgeNumber:0];
+                });
             }
             NSLog(@"PushPlugin.register: clear badge is set to %d", clearBadge);
 


### PR DESCRIPTION
## Description
Prior to fix xcode was bonking when running UITests 

Error received in xcode prior to fix: `[UIApplication applicationIconBadgeNumber] must be used from main thread
`
Followed documentation here for fix - https://developer.apple.com/documentation/code_diagnostics/main_thread_checker

## Related Issue
Seems to be similar to this issue - [https://github.com/phonegap/phonegap-plugin-push/issues/2901](url)

## Motivation and Context
Main Thread Checker is enabled by default in Xcode. If we manually disable the MTC the UITests work great, however since we are rebuilding the scheme when we rebuild the .ipa file this won't work for our automation purposes.